### PR TITLE
fix: build in dependency order, disable gnosis-safe package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "workspaces": {
     "packages": [
+      "packages/shared",
+      "packages/request-ui",
       "packages/*"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "packages": [
       "packages/shared",
       "packages/request-ui",
-      "packages/*"
+      "packages/create",
+      "packages/pay"
     ]
   }
 }


### PR DESCRIPTION
Closes #33

# Changes

- Build packages in dependency order
- Disable `gnosis-safe` package.  Failing due to error:
```console
> request-gnosis-safe
yarn run v1.22.19
$ NODE_OPTIONS=--max_old_space_size=8192 react-scripts build
Creating an optimized production build...
Failed to compile.

/home/david/projects/request-apps/packages/gnosis-safe/src/components/CreateRequest.tsx
TypeScript error in /home/david/projects/request-apps/packages/gnosis-safe/src/components/CreateRequest.tsx(113,23):
Property 'DaiIcon' does not exist on type 'typeof import("/home/david/projects/request-apps/packages/request-ui/dist/currencies/index")'.  TS2339

    111 |   if (network === 1) {
    112 |     return {
  > 113 |       DAI: currencies.DaiIcon,
        |                       ^
    114 |       ETH: currencies.EthIcon,
    115 |       // USDT: UsdtIcon,
    116 |       USDC: currencies.UsdcIcon,


error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
Command: /home/david/.nvm/versions/node/v16.10.0/bin/node
Arguments: /home/david/.nvm/versions/node/v16.10.0/lib/node_modules/yarn/lib/cli.js run build
Directory: /home/david/projects/request-apps/packages/gnosis-safe
Output:

info Visit https://yarnpkg.com/en/docs/cli/workspaces for documentation about this command.
```