### PR TITLE
Add chain to the Metamask if it does not exist

### DIFF
--- a/packages/shared/src/index.tsx
+++ b/packages/shared/src/index.tsx
@@ -61,14 +61,14 @@ export const chainInfos: Record<string | number, ChainInfo> = {
     id: "xdai",
     color: "#48a900",
     chainId: 100,
-    name: "xDAI Chain",
-    rpcUrls: ["https://gnosischain-rpc.gateway.pokt.network/"],
+    name: "Gnosis",
+    rpcUrls: ["https://rpc.gnosischain.com/"],
     nativeCurrency: {
       name: "xDAI",
-      symbol: "xDAI",
+      symbol: "XDAI",
       decimals: 18,
     },
-    blockExplorerUrls: ["https://gnosischain.io/"],
+    blockExplorerUrls: ["https://gnosisscan.io/"],
   },
   matic: {
     id: "matic",

--- a/packages/shared/src/index.tsx
+++ b/packages/shared/src/index.tsx
@@ -96,7 +96,7 @@ export const chainInfos: Record<string | number, ChainInfo> = {
   },
 };
 
-export const addEthereumChain = (
+export const addEthereumChain = async (
   chain: string | number,
   library?: providers.Web3Provider
 ) => {
@@ -108,16 +108,16 @@ export const addEthereumChain = (
 
   // first attempt to switch to that chain
   try {
-    return library.send("wallet_switchEthereumChain", [
+    return await library.send("wallet_switchEthereumChain", [
       { chainId: utils.hexValue(chainId) },
     ]);
-  } catch {}
+  } catch { }
 
   if (!rpcUrls || rpcUrls.length === 0) {
     return null;
   }
 
-  return library.send("wallet_addEthereumChain", [
+  return await library.send("wallet_addEthereumChain", [
     {
       chainId: utils.hexValue(chainId),
       chainName: name,


### PR DESCRIPTION
Fixes #51 

- Modified the `addEthereumChain` function to await while sending the `wallet_switchEthereumChain` message to the Web3Provider. It was not awaiting the promise earlier, so the error was not caught if the network was absent. Now, the whole try-catch flow works as expected.
- Also, updated the chain details to clear the metamask warnings.

![Metamask warning](https://github.com/RequestNetwork/request-apps/assets/55619686/918f118d-48d3-4075-82d0-d4a4d1c2469c)

[Demo.webm](https://github.com/RequestNetwork/request-apps/assets/55619686/93edd360-21e0-428b-afcf-ba80cf070c26)
